### PR TITLE
Fixed Android Importing

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -66,7 +66,7 @@ eclipse {
     }
 
     classpath {
-        plusConfigurations += project.configurations.compile        
+        plusConfigurations += [ project.configurations.compile ]       
         containers 'com.android.ide.eclipse.adt.ANDROID_FRAMEWORK', 'com.android.ide.eclipse.adt.LIBRARIES'       
     }
 


### PR DESCRIPTION
Eclipse will fail to import the project without this change.